### PR TITLE
#81 Spieler Namen in Lobby laden

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/Lobby.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/Lobby.java
@@ -70,6 +70,16 @@ public class Lobby {
         return playerIDs;
     }
 
+    public List<String> getPlayerNames() {
+        List<String> playerNames = new ArrayList<>();
+
+        for (Player player : players) {
+            playerNames.add(player.getPlayerName());
+        }
+
+        return playerNames;
+    }
+
     public Player getPlayerByID(String playerID) {
         for (Player player : players) {
             if (player.getPlayerID().equals(playerID)) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyManager.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyManager.java
@@ -140,4 +140,9 @@ public class LobbyManager {
         Lobby lobby = getLobbyByCode(code);
         lobby.setGaiaHolderAsStartPlayer();
     }
+
+    public List<String> getPlayerNamesForLobby(String code) throws Exception {
+        Lobby lobby = getLobbyByCode(code);
+        return lobby.getPlayerNames();
+    }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GetPlayersInLobbyMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GetPlayersInLobbyMessage.java
@@ -1,0 +1,15 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class GetPlayersInLobbyMessage {
+    @JsonProperty("lobbyCode")
+    private String lobbyCode;
+
+    @JsonProperty("playerNames")
+    private List<String> playerNames;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GetPlayersInLobbyRequest.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GetPlayersInLobbyRequest.java
@@ -1,0 +1,10 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class GetPlayersInLobbyRequest {
+    @JsonProperty("lobbyCode")
+    private String lobbyCode;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -11,8 +11,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.util.HtmlUtils;
+
+import java.util.List;
 
 @Controller
 public class WebSocketBrokerController {
@@ -44,6 +47,15 @@ public class WebSocketBrokerController {
         lobbyManager.addPlayerToLobby(joinLobbyRequest.getLobbyCode(), joinLobbyRequest.getUserID(), joinLobbyRequest.getUserName());
         sendPlayerJoinedLobbyMessage(joinLobbyRequest.getUserName());
         return joinLobbyRequest.getLobbyCode();
+    }
+
+    @MessageMapping("/get_players_in_lobby")
+    @SendTo("/topic/players_in_lobby")
+    public String getPlayersInLobby(GetPlayersInLobbyRequest playersInLobbyRequest) throws Exception {
+        List<String> playerNames = lobbyManager.getPlayerNamesForLobby(playersInLobbyRequest.getLobbyCode());
+        GetPlayersInLobbyMessage playersInLobbyMessage = new GetPlayersInLobbyMessage();
+        playersInLobbyMessage.setPlayerNames(playerNames);
+        return objectMapper.writeValueAsString(playersInLobbyMessage);
     }
 
     @MessageMapping("/deal_new_round")

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -54,6 +54,7 @@ public class WebSocketBrokerController {
     public String getPlayersInLobby(GetPlayersInLobbyRequest playersInLobbyRequest) throws Exception {
         List<String> playerNames = lobbyManager.getPlayerNamesForLobby(playersInLobbyRequest.getLobbyCode());
         GetPlayersInLobbyMessage playersInLobbyMessage = new GetPlayersInLobbyMessage();
+        playersInLobbyMessage.setLobbyCode(playersInLobbyRequest.getLobbyCode());
         playersInLobbyMessage.setPlayerNames(playerNames);
         return objectMapper.writeValueAsString(playersInLobbyMessage);
     }

--- a/src/test/java/at/aau/serg/websocketdemoserver/WebSocketBrokerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/WebSocketBrokerIntegrationTest.java
@@ -227,23 +227,9 @@ class WebSocketBrokerIntegrationTest {
         assertThat(createLobbyResponse).isNotEmpty();
         assertEquals(createLobbyResponse.length(), LobbyManager.LOBBY_CODE_LENGTH);
 
-        StompSession sessionJoin = initStompSession(WEBSOCKET_TOPIC_JOIN_LOBBY_RESPONSE);
-        initStompSession(WEBSOCKET_TOPIC_PLAYER_JOINED_LOBBY_RESPONSE);
-
-        String userIDJoin = "TEST_USER_ID_2";
-        String userNameJoin = "TEST_USER_NAME_2";
-
-        JSONObject joinLobbyPayload = new JSONObject();
-        joinLobbyPayload.put("lobbyCode", createLobbyResponse);
-        joinLobbyPayload.put("userID", userIDJoin);
-        joinLobbyPayload.put("userName", userNameJoin);
-
-        sessionJoin.send(WEBSOCKET_TOPIC_JOIN_LOBBY, joinLobbyPayload);
-
         StompSession sessionPlayersInLobby = initStompSession(WEBSOCKET_TOPIC_GET_PLAYERS_IN_LOBBY_RESPONSE);
-
         JSONObject getLobbyPlayersRequest = new JSONObject();
-        joinLobbyPayload.put("lobbyCode", createLobbyResponse);
+        getLobbyPlayersRequest.put("lobbyCode", createLobbyResponse);
         sessionPlayersInLobby.send(WEBSOCKET_TOPIC_GET_PLAYERS_IN_LOBBY, getLobbyPlayersRequest);
 
         String playersResponse = messages.poll(1, TimeUnit.SECONDS);

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyManagerUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyManagerUnitTest.java
@@ -99,6 +99,16 @@ public class LobbyManagerUnitTest {
     }
 
     @Test
+    public void testGetPlayerNames() throws Exception {
+        String lobbyCode = lobbyManager.createLobby();
+        String playerID = "user1";
+        String playerName = "USER_NAME";
+
+        lobbyManager.addPlayerToLobby(lobbyCode, playerID, playerName);
+        assertTrue(lobbyManager.getPlayerNamesForLobby(lobbyCode).contains(playerName));
+    }
+
+    @Test
     public void testAddUserToNonexistentLobby() {
         String lobbyCode = "lobby1";
         String userID = "user1";

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyManagerUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyManagerUnitTest.java
@@ -93,6 +93,7 @@ public class LobbyManagerUnitTest {
         for (Lobby lobby : lobbies) {
             if (lobby.getLobbyCode().equals(lobbyCode)) {
                 assertTrue(lobby.getPlayerIDs().contains(playerID));
+                assertTrue(lobby.getPlayerNames().contains(playerName));
             }
         }
     }

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/LobbyUnitTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -359,5 +361,17 @@ public class LobbyUnitTest {
         expected.get("test3").put(1,1);
 
         Assertions.assertEquals(expected, lobby.getPlayerPoints());
+    }
+
+    @Test
+    void testGetPlayerNames() {
+        lobby.addPlayer(new Player("player1", "test1"));
+        lobby.addPlayer(new Player("player2", "test2"));
+        lobby.addPlayer(new Player("player3", "test3"));
+
+        List<String> playerNames = lobby.getPlayerNames();
+        assertEquals(playerNames.get(0), "test1");
+        assertEquals(playerNames.get(1), "test2");
+        assertEquals(playerNames.get(2), "test3");
     }
 }


### PR DESCRIPTION
- Spieler Namen für Spieler in der Lobby können jetzt unabhängig geladen werden -> soll aufgerufen werden wenn einer Lobby beigetreten wird